### PR TITLE
feat: 임베딩 모델 토큰 제한을 위한 content guard 추가

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,5 +20,8 @@ opencv-python>=4.8.0
 pytesseract>=0.3.10
 numpy>=1.24.0
 
+# Tokenizer for embedding length control
+transformers>=4.40.0
+
 # Additional utilities
 requests>=2.31.0

--- a/scripts/adrule/logic/scraper.py
+++ b/scripts/adrule/logic/scraper.py
@@ -20,6 +20,7 @@ from datetime import datetime
 project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
 sys.path.append(project_root)
 
+from scripts.core.content_guard import apply_content_guard
 from scripts.utils.logger_config import get_logger
 from scripts.utils.ocr import call_clova_ocr
 from scripts.core.database.unified_repository import UnifiedDocumentRepository
@@ -486,6 +487,9 @@ def save_to_mongodb(chunks: list, doc_title: str, doc_id: str, url: str, dept_co
                 # 부처 코드 추가
                 if dept_code:
                     article_doc["metadata"]["dept_code"] = dept_code
+
+                # 임베딩 모델 컨텍스트 길이 제한
+                article_doc = apply_content_guard(article_doc)
 
                 # MongoDB에 upsert
                 result = collection.update_one(

--- a/scripts/case/logic/scraper.py
+++ b/scripts/case/logic/scraper.py
@@ -14,6 +14,8 @@ from datetime import datetime
 project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
 sys.path.append(project_root)
 
+from scripts.core.content_guard import apply_content_guard
+
 # --- 로거 설정 ---
 from scripts.utils.logger_config import get_logger
 logger = get_logger(__name__, scraper_type='case')
@@ -340,6 +342,9 @@ def save_case_chunks_to_mongodb(
                     }
                 }
                 
+                # 임베딩 모델 컨텍스트 길이 제한
+                chunk_doc = apply_content_guard(chunk_doc)
+
                 # 청크별 upsert
                 result = collection.update_one(
                     {"doc_id": chunk_doc_id},

--- a/scripts/core/content_guard.py
+++ b/scripts/core/content_guard.py
@@ -1,0 +1,64 @@
+"""
+Content length guard for embedding compatibility.
+
+Uses the actual tokenizer from the embedding model (kakao1513/KURE-legal-ft-v1)
+to enforce the 8,192 token context limit. Applied before every MongoDB save
+so all documents in original_db are embedding-ready.
+"""
+
+import logging
+from transformers import AutoTokenizer
+
+logger = logging.getLogger(__name__)
+
+MODEL_NAME = "kakao1513/KURE-legal-ft-v1"
+MAX_TOKENS = 8192
+
+# Load once at module level — tokenizer is lightweight
+_tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
+
+
+def truncate_to_max_tokens(text: str, max_tokens: int = MAX_TOKENS) -> str:
+    """Truncate text to fit within max_tokens using the actual tokenizer."""
+    if not text:
+        return ""
+    enc = _tokenizer(
+        text,
+        truncation=True,
+        max_length=max_tokens,
+        add_special_tokens=False,
+        return_attention_mask=False,
+        return_token_type_ids=False,
+    )
+    return _tokenizer.decode(enc["input_ids"], skip_special_tokens=True)
+
+
+def apply_content_guard(doc: dict, max_tokens: int = MAX_TOKENS) -> dict:
+    """Truncate the content field if it exceeds max_tokens.
+
+    Adds metadata flags for traceability.
+    """
+    content = doc.get("content")
+    if not content or not isinstance(content, str):
+        return doc
+
+    token_count = len(_tokenizer.encode(content, add_special_tokens=False))
+    if token_count <= max_tokens:
+        return doc
+
+    original_len = len(content)
+    original_tokens = token_count
+
+    doc["content"] = truncate_to_max_tokens(content, max_tokens)
+
+    if "metadata" not in doc:
+        doc["metadata"] = {}
+    doc["metadata"]["content_truncated"] = True
+    doc["metadata"]["original_content_length"] = original_len
+    doc["metadata"]["original_token_count"] = original_tokens
+
+    logger.debug(
+        f"[content_guard] doc_id={doc.get('doc_id', '?')} "
+        f"truncated {original_tokens} → {max_tokens} tokens"
+    )
+    return doc

--- a/scripts/interpretation/logic/scraper.py
+++ b/scripts/interpretation/logic/scraper.py
@@ -17,6 +17,7 @@ except NameError:
     project_root = os.path.abspath('.') # 현재 작업 디렉토리를 기준으로 설정
 sys.path.append(project_root)
 
+from scripts.core.content_guard import apply_content_guard
 from scripts.utils.logger_config import get_logger
 
 # 스크레이퍼 타입에 맞는 로거 생성
@@ -136,6 +137,9 @@ def save_to_mongodb(sections_data: list, doc_title: str, doc_id: str, url: str,
                     }
                 }
                 
+                # 임베딩 모델 컨텍스트 길이 제한
+                section_doc = apply_content_guard(section_doc)
+
                 # MongoDB에 upsert
                 result = collection.update_one(
                     {"doc_id": doc_id, "article_number": article_number},

--- a/scripts/law/logic/scraper.py
+++ b/scripts/law/logic/scraper.py
@@ -12,6 +12,7 @@ from typing import Optional, Dict, List, Tuple
 
 project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
 sys.path.append(project_root)
+from scripts.core.content_guard import apply_content_guard
 
 from scripts.utils.logger_config import get_logger
 from scripts.core.database.unified_repository import UnifiedDocumentRepository
@@ -306,6 +307,9 @@ def save_to_mongodb(unified_doc: Dict, dept_code: Optional[str] = None) -> bool:
                 if dept_code:
                     article_doc["metadata"]["dept_code"] = dept_code
                 
+                # 임베딩 모델 컨텍스트 길이 제한
+                article_doc = apply_content_guard(article_doc)
+
                 # 변경 감지 포함 upsert
                 doc_id, action_result = repo.upsert_with_change_detection(article_doc)
                 


### PR DESCRIPTION
임베딩 모델(KURE-legal-ft-v1)의 최대 컨텍스트 8,192 토큰 제한에 맞춰, MongoDB 저장 전 문서 content를 실제 토크나이저로 검사 및 truncate하는 공유 모듈(content_guard.py)을 추가. law, case, adrule, interpretation 4개 스크레이퍼의 저장 로직에 통합.