### PR TITLE
fix(interpretation): 문서 날짜를 zero-padding 해서 저장

### DIFF
--- a/scripts/interpretation/logic/scraper.py
+++ b/scripts/interpretation/logic/scraper.py
@@ -24,6 +24,35 @@ from scripts.core.database.source_versioning import enrich_source_document
 # 스크레이퍼 타입에 맞는 로거 생성
 logger = get_logger(__name__, scraper_type='interpretation')
 
+def normalize_doc_date(doc_date):
+    """'2006.9.1' 같은 문서 날짜를 'YYYY-MM-DD' 로 정규화한다 (zero-padding 포함).
+
+    parse_subtitle 이 뽑아내는 날짜는 원문 표기를 그대로 따라가서 월·일이 한 자리일
+    수 있다(`[고용노동부 임금근로시간정책팀-2534, 2006. 9. 1.]`). 기존에는
+    `doc_date.replace(".", "-")` 로만 바꿔서 "2006-9-1" 이 그대로 저장됐다.
+
+    metadata.effective 는 문자열로 저장되고 검색 단계에서 **사전식으로** 비교되므로
+    (chat_generation retriever 의 $gte/$lte), 자리수가 맞지 않으면 순서가 깨진다:
+        "2006-9-1" > "2006-12-31"   ← 한 자리 월이 12월보다 뒤로 간다
+    실제로 운영 DB 표본 4,000건 중 3,238건(81%)이 이 상태였고, interpretation 에
+    걸리는 날짜 필터가 조용히 잘못된 결과를 내고 있었다. (기존 데이터는 MongoDB 에서
+    일괄 정정함 — 11,681건.)
+
+    law/adrule/case 스크래퍼는 이미 `.zfill(2)` 로 맞춰 저장한다. 이 함수는
+    interpretation 을 같은 규약에 맞춘다.
+
+    파싱할 수 없으면 빈 문자열을 반환한다 — 호출부가 기존 폴백을 그대로 적용한다.
+    """
+    if not doc_date:
+        return ""
+    m = re.match(r"^\s*(\d{4})\s*\.\s*(\d{1,2})\s*\.\s*(\d{1,2})\s*\.?\s*$", str(doc_date))
+    if not m:
+        logger.debug(f"날짜 정규화 실패(형식 불일치): {doc_date!r}")
+        return ""
+    year, month, day = m.groups()
+    return f"{year}-{month.zfill(2)}-{day.zfill(2)}"
+
+
 def parse_subtitle(subtitle_text):
     """부제목 text에서 부서, 문서번호, 날짜를 추출합니다."""
     logger.debug(f"Subtitle 파싱 시도: {subtitle_text}")
@@ -122,7 +151,7 @@ def _parse_taxlaw_body(body_text: str) -> dict | None:
     return {
         "doc_title": doc_title,
         "sub_title": ", ".join(part for part in ["국세청", doc_number, doc_date] if part),
-        "effective_date": doc_date.replace(".", "-") if doc_date else datetime.now().strftime('%Y-%m-%d'),
+        "effective_date": normalize_doc_date(doc_date) or datetime.now().strftime('%Y-%m-%d'),
         "sections_data": split_sections_by_header(sections),
     }
 
@@ -348,7 +377,10 @@ async def scrape_and_save(url: str, output_dir: str, output_name: str, dept_code
                 effective_date = datetime.now().strftime('%Y-%m-%d')
                 if doc_date and doc_date != "정보 없음":
                     try:
-                        effective_date = doc_date.replace(".", "-")
+                        # zero-padding 포함 정규화. 실패하면 위의 폴백을 유지한다.
+                        normalized = normalize_doc_date(doc_date)
+                        if normalized:
+                            effective_date = normalized
                     except Exception:
                         pass
 


### PR DESCRIPTION
## 문제

`parse_subtitle` 이 뽑는 날짜는 원문 표기를 그대로 따라가 월·일이 한 자리일 수 있다:

```
[고용노동부 임금근로시간정책팀-2534, 2006. 9. 1.]   →  doc_date = "2006.9.1"
```

기존 코드는 `doc_date.replace(".", "-")` 로만 바꿔 **`"2006-9-1"`** 을 그대로 저장했다.

`metadata.effective` 는 문자열로 저장되고 검색 단계에서 **사전식으로** 비교된다(chat_generation retriever 의 `$gte`/`$lte`). 자리수가 어긋나면 순서가 깨진다:

```
"2006-9-1"  >  "2006-12-31"     ← 한 자리 월이 12월보다 뒤로 간다
```

**운영 DB 표본 4,000건 중 3,238건(81%)** 이 이 상태였다. `"2020년 이후 행정해석"` 같은 질의의 날짜 필터가 조용히 잘못된 결과를 내고 있었다 — 에러도 경고도 없이.

`law` / `adrule` / `case` 스크래퍼는 이미 `.zfill(2)` 를 쓴다. **interpretation 만 규약에서 벗어나 있었다.**

## 변경

- **`normalize_doc_date()`** 신설 — `'YYYY.M.D'` → `'YYYY-MM-DD'` (zero-padding 포함). 공백 포함 표기(`"2006. 9. 1."`)도 처리. 파싱 실패 시 빈 문자열을 반환해 **호출부의 기존 폴백을 그대로 유지**한다.
- 변환 지점 **2곳** 교체: 국세청 파서(125행), 메인 스크래퍼 루프(348-351행).

## 검증

단위 테스트 10종 — 실제 관측값(`2006.9.1`, `2023.7.10`, `2023.7.4`), 공백 포함 표기, 파싱 불가 입력(`정보 없음`, `None`, 빈 문자열) 전부 통과.

```
OLD:  '2006-9-1'  > '2006-12-31'  ->  True    ← 버그
NEW:  '2006-09-01' > '2006-12-31' ->  False   ← 정상
```

## 기존 데이터

MongoDB 에서 일괄 정정 완료 — **11,681건**(11,198건 zero-padding, 빈 문자열 483건은 `None` 으로). 정정 후 unpadded **0건** 확인.

빈 문자열을 `None` 으로 바꾼 이유: `""` 는 날짜 비교에도 걸리지 않고 `null`/`missing` 관대 조항에도 걸리지 않아, `after` 필터에서 조용히 배제되고 있었다. `None` 이면 "날짜 모름"으로 취급돼 통과한다.

## ⚠️ 남은 문제 (이 PR 범위 밖)

날짜 파싱에 실패하면 `datetime.now()` 로 폴백한다(125행, 348행). 즉 **회신일을 알 수 없는 문서에 크롤한 날짜가 박히고**, 진짜 그날 회신된 문서와 구분할 방법이 없다. `law`/`adrule` 스크래퍼도 같은 구조다.

값을 비워 두는 편이 데이터 정합성 면에서 안전하지만, 다운스트림이 비어 있지 않은 문자열을 기대할 수 있어 이번 변경에는 포함하지 않았다. 별도 판단 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)