### PR TITLE
feat(judgment): 사건번호를 판정문 본문에서 추출 — 스크레이퍼 폴백 + 백필

### DIFF
--- a/scripts/judgment/logic/scraper.py
+++ b/scripts/judgment/logic/scraper.py
@@ -17,7 +17,10 @@ sys.path.append(project_root)
 from scripts.utils.logger_config import get_logger
 from scripts.utils.nlrc_pdf import extract_attachment_text, pdf_retry_needed
 from scripts.core.identifiers import document_chunk_id
-from scripts.utils.reference_sub_title import extract_nlrc_case_number
+from scripts.utils.reference_sub_title import (
+    extract_nlrc_case_number,
+    extract_nlrc_case_number_from_body,
+)
 from scripts.core.database.source_versioning import enrich_source_document, sha256_content
 
 logger = get_logger(__name__, scraper_type='judgment')
@@ -194,7 +197,14 @@ async def scrape_and_save(url: str | dict, output_dir: str, output_name: str, de
             "doc_type": "주요판정사례",
             "article_number": "1",
             "title": parsed.get("title"),
-            "sub_title": extract_nlrc_case_number(parsed.get("title") or ""),
+            # 제목에 사건번호가 없는 문서(구세대 312/411)가 다수라, 첨부 판정문
+            # 본문에서 한 번 더 추출한다. 상세 페이지에는 사건번호 필드가 없어
+            # (2026-08-19 실측) 본문이 유일한 폴백이다. sub_title 이 비면 FE 출처
+            # 라벨이 제목 문장으로 나가는 문제의 재발 방지.
+            "sub_title": (
+                extract_nlrc_case_number(parsed.get("title") or "")
+                or extract_nlrc_case_number_from_body(content)
+            ),
             "content": content,
             "metadata": {
                 "source_url": detail_url,

--- a/scripts/migrations/backfill_judgment_case_numbers.py
+++ b/scripts/migrations/backfill_judgment_case_numbers.py
@@ -1,0 +1,97 @@
+"""judgment(주요판정사례) 빈 sub_title 을 판정문 본문에서 복구한다.
+
+배경 (2026-08-19 실측):
+  · judgment 411건 중 312건이 sub_title 공백 → FE 출처 라벨이 사건번호 대신
+    제목 문장으로 노출.
+  · 크롤러는 제목에서만 사건번호를 추출했는데, 구세대 문서의 제목은 서술문이다.
+  · nlrc.go.kr 상세 페이지에는 사건번호 필드가 아예 없어(BD_table 실측) 재크롤로
+    해결 불가 — 이미 저장된 첨부 판정문 본문이 유일한 소스이며, 여기서 221건이
+    복구 가능했다.
+
+Read-only by default. Pass ``--apply`` to update MongoDB.
+본문(content)은 건드리지 않으므로 임베딩 재계산이 필요 없다.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+
+from scripts.core.database.mongo_client import get_mongo_db
+from scripts.utils.reference_sub_title import (
+    extract_nlrc_case_number,
+    extract_nlrc_case_number_from_body,
+)
+
+_EMPTY_SUB_TITLE = {"$or": [
+    {"sub_title": None},
+    {"sub_title": ""},
+    {"sub_title": {"$exists": False}},
+]}
+
+
+def backfill(apply: bool, sample_limit: int = 15) -> Counter:
+    db = get_mongo_db()
+    collection = db["judgment"]
+    stats = Counter()
+    samples: list[tuple[str, str]] = []
+
+    doc_ids = collection.distinct("doc_id", _EMPTY_SUB_TITLE)
+    for doc_id in doc_ids:
+        rows = list(collection.find(
+            {"doc_id": doc_id},
+            {"title": 1, "content": 1, "sub_title": 1},
+        ))
+        # 다른 청크에 이미 sub_title 이 있으면(부분 공백) 그 값을 재사용한다.
+        existing = next(
+            (str(r.get("sub_title")) for r in rows if str(r.get("sub_title") or "").strip()),
+            "",
+        )
+        title = next((r.get("title") for r in rows if r.get("title")), "") or ""
+        full_text = "\n".join((r.get("content") or "") for r in rows)
+
+        case_number = (
+            existing
+            or extract_nlrc_case_number(title)
+            or extract_nlrc_case_number_from_body(full_text)
+        )
+
+        stats["documents"] += 1
+        if not case_number:
+            stats["unrecoverable"] += 1
+            continue
+
+        stats["recovered"] += 1
+        if len(samples) < sample_limit:
+            samples.append((str(doc_id), case_number))
+
+        if apply:
+            result = collection.update_many(
+                {"doc_id": doc_id, **_EMPTY_SUB_TITLE},
+                {"$set": {"sub_title": case_number}},
+            )
+            stats["updated_rows"] += result.modified_count
+        else:
+            stats["would_update_rows"] += collection.count_documents(
+                {"doc_id": doc_id, **_EMPTY_SUB_TITLE}
+            )
+
+    print(f"\n== judgment sub_title backfill ({'APPLY' if apply else 'DRY-RUN'}) ==")
+    for key in ("documents", "recovered", "unrecoverable", "updated_rows", "would_update_rows"):
+        if stats.get(key):
+            print(f"  {key}: {stats[key]}")
+    print("  sample mappings:")
+    for doc_id, case_number in samples:
+        print(f"    doc_id={doc_id} → {case_number}")
+    return stats
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--apply", action="store_true", help="실제로 MongoDB를 갱신한다")
+    args = parser.parse_args()
+    backfill(apply=args.apply)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/utils/reference_sub_title.py
+++ b/scripts/utils/reference_sub_title.py
@@ -38,6 +38,39 @@ def extract_nlrc_case_number(title: str) -> str:
     return re.sub(r"\s+", "", match.group(1)) if match else ""
 
 
+# 판정문 헤더의 '사    건' 라벨. normalize_reference_text 가 공백 런을 한 칸으로
+# 접으므로 헤더는 "사 건 중앙…"이 되고, 본문 산문의 "이 사건 근로자"("사건",
+# 붙어 씀)와 구분된다. 앞뒤에 한글이 붙은 경우는 라벨이 아니다.
+_NLRC_BODY_CASE_LABEL = re.compile(r"(?<![가-힣])사 건(?![가-힣])")
+_NLRC_BODY_HEAD_CHARS = 6000
+
+
+def extract_nlrc_case_number_from_body(text: str) -> str:
+    """판정문 본문(첨부 PDF 전문 포함)에서 이 문서 자신의 사건번호를 추출한다.
+
+    nlrc.go.kr 상세 페이지에는 사건번호 필드가 아예 없어(실측 2026-08-19,
+    BD_table 항목: 자료구분/담당부서/…/판정사항/판정요지/첨부파일) 제목에 번호가
+    없는 문서는 첨부 판정문 본문이 유일한 소스다.
+
+    본문에는 초심(지노위) 번호 등 다른 사건의 번호도 인용되므로 순서를 지킨다:
+      1) '사 건' 라벨 뒤 120자 안의 번호 — 판정문 헤더의 자기 사건번호
+      2) 라벨이 없으면 본문 앞부분(6,000자)의 첫 번째 번호
+    """
+    normalized = normalize_reference_text(text)
+    if not normalized:
+        return ""
+    head = normalized[:_NLRC_BODY_HEAD_CHARS]
+
+    for label in _NLRC_BODY_CASE_LABEL.finditer(head):
+        segment = head[label.end(): label.end() + 120]
+        match = NLRC_CASE_NUMBER.search(segment)
+        if match:
+            return re.sub(r"\s+", "", match.group(1))
+
+    match = NLRC_CASE_NUMBER.search(head)
+    return re.sub(r"\s+", "", match.group(1)) if match else ""
+
+
 def legacy_pdf_case_sub_title(title: str) -> str:
     """Use a legacy PDF judgment title as its citation subtitle when numbered."""
     normalized = normalize_reference_text(title)

--- a/tests/test_reference_sub_title_body.py
+++ b/tests/test_reference_sub_title_body.py
@@ -1,0 +1,47 @@
+"""판정문 본문에서 자기 사건번호를 추출하는 규칙을 고정한다.
+
+본문에는 초심(지노위) 번호 등 다른 사건의 번호가 함께 인용되므로,
+'사 건' 라벨(판정문 헤더) 우선 규칙이 깨지면 엉뚱한 번호가 라벨에 박힌다.
+"""
+
+from scripts.utils.reference_sub_title import extract_nlrc_case_number_from_body
+
+
+HEADER_BODY = (
+    "판정사항: 해고의 징계가 정당하다고 판정한 사례\n\n"
+    "[첨부파일 전문]\n중앙노동위원회 판정서\n"
+    "사    건 중앙2014부해781 부당해고 구제 재심신청\n"
+    "근로자 김OO\n"
+    "이 사건 근로자는 초심 서울2014부해321 사건에서 구제를 신청하였다."
+)
+
+
+def test_prefers_case_number_after_the_case_label():
+    assert extract_nlrc_case_number_from_body(HEADER_BODY) == "중앙2014부해781"
+
+
+def test_label_wins_even_when_another_number_appears_first():
+    body = (
+        "초심 서울2014부해321 판정에 불복하여 재심을 신청한 사건이다.\n"
+        "사    건 중앙2015부해873 부당해고 구제 재심신청"
+    )
+    assert extract_nlrc_case_number_from_body(body) == "중앙2015부해873"
+
+
+def test_prose_sagun_does_not_trigger_the_label_rule():
+    """'이 사건 근로자'(붙여 쓴 사건)는 라벨이 아니다 — 라벨 없으면 첫 번호."""
+    body = (
+        "이 사건 근로자는 부당해고를 다투었다. "
+        "초심 서울2016부해100 판정이 유지되었다."
+    )
+    assert extract_nlrc_case_number_from_body(body) == "서울2016부해100"
+
+
+def test_returns_empty_when_no_case_number_exists():
+    assert extract_nlrc_case_number_from_body("판정사항: 근로자성이 부정된 사례") == ""
+    assert extract_nlrc_case_number_from_body("") == ""
+
+
+def test_whitespace_inside_number_is_collapsed():
+    body = "사    건 중앙 2019 부해 321 부당해고 구제 재심신청"
+    assert extract_nlrc_case_number_from_body(body) == "중앙2019부해321"


### PR DESCRIPTION
## 배경

주요판정사례(judgment) 출처 라벨이 사건번호("중앙2020부해26") 대신 제목 문장으로 노출되는 문제. 411건 중 312건이 `sub_title` 공백이었고, 원인은:

- 크롤러가 사건번호를 **제목에서만** 정규식 추출 (`extract_nlrc_case_number(title)`) — 구세대 문서 제목은 서술문
- **nlrc.go.kr 상세 페이지에는 사건번호 필드가 아예 없음** (실측: BD_table = 자료구분/담당부서/…/판정사항/판정요지/첨부파일) → 재크롤로 해결 불가
- 유일한 소스는 이미 저장된 첨부 판정문 PDF 본문

## 변경

- `extract_nlrc_case_number_from_body`: '사 건' 라벨(판정문 헤더) 뒤 번호 우선, 없으면 본문 앞 6,000자의 첫 번호. normalize 후 공백 유무로 산문의 "이 사건"과 구분 — 초심(지노위) 번호 오인 방지
- 스크레이퍼: 제목 추출 실패 시 본문 폴백 (재발 방지)
- 백필 스크립트(dry-run 기본, `--apply`): content 불변이라 재임베딩 불필요

## 검증 (맥미니, worktree 격리)

- 전체 테스트 109건 통과 (신규 5건 포함)
- 백필 dry-run → apply 완료: **312건 중 212건 복구, 현재 사건번호 보유 311/411**
- 스크레이퍼 스모크(save_to_db=False): 배선 정상. 단 해당 문서는 스캔 PDF인데 **OpenAI OCR 크레딧 소진(429 insufficient_quota)** 으로 본문 추출 실패 — 본 PR과 무관한 기존 운영 이슈로, 미복구 100건의 원인. 크레딧 충전 후 pdf_retry 경로에서 재추출되면 스크레이퍼 폴백이 사건번호도 함께 채움

## 배포 메모

⚠️ 맥미니 작업본(main)에 **커밋 안 된 WIP**(scraper.py 수정, pdf_text_cleaner.py 신규 — clean-pdf-artifacts 작업)가 있어 merge 후에도 맥미니 pull은 보류. WIP를 커밋/푸시한 뒤 동기화 필요 (충돌: scraper.py)

🤖 Generated with [Claude Code](https://claude.com/claude-code)