### PR TITLE
fix(crawler): PDF 출처·파싱 흔적 제거 (hrdb 프린트 푸터, 페이지 마커, 첨부 파일명)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ send_discord*.py
 timing_check.py
 verify_mongo.py
 /tmp/
+
+# 재사용 백필 (PDF 출처/파싱 흔적 제거) — 추적 대상
+!scripts/migrations/backfill_clean_pdf_artifacts.py

--- a/scripts/judgment/logic/scraper.py
+++ b/scripts/judgment/logic/scraper.py
@@ -16,6 +16,7 @@ sys.path.append(project_root)
 
 from scripts.utils.logger_config import get_logger
 from scripts.utils.nlrc_pdf import extract_attachment_text, pdf_retry_needed
+from scripts.utils.pdf_text_cleaner import clean_pdf_artifacts
 from scripts.core.identifiers import document_chunk_id
 from scripts.utils.reference_sub_title import extract_nlrc_case_number
 from scripts.core.database.source_versioning import enrich_source_document, sha256_content
@@ -185,6 +186,10 @@ async def scrape_and_save(url: str | dict, output_dir: str, output_name: str, de
                 f"⚠️ {doc_id}: 첨부파일 본문 추출 실패 — HTML 요약 유지 "
                 f"({pdf_result['error']})"
             )
+
+        # Strip PDF page markers / attachment-filename markers so the citation
+        # panel and public search show clean text.
+        content = clean_pdf_artifacts(content)
 
         attachment = pdf_result.get("attachment") or {}
 

--- a/scripts/migrations/backfill_clean_pdf_artifacts.py
+++ b/scripts/migrations/backfill_clean_pdf_artifacts.py
@@ -1,0 +1,143 @@
+"""Backfill: strip PDF/print artifacts from existing MongoDB content.
+
+Cleans documents already stored in ``original_db`` whose ``content`` carries
+PDF print/page artifacts (hrdb.kr print footers, NLRC ``- N -`` page markers,
+``[첨부: ...]`` filename markers) and flags title/source-only stub documents so
+they stay out of the public search surface and the B2B citation panel.
+
+When a document's content changes, ``content_hash`` and ``source_version_id``
+are recomputed with the same helpers the ingest pipeline uses, so the
+re-embedding job can detect the change (the stale ``embedding`` is not touched
+here — re-embedding is owned by the chat_generation pipeline).
+
+Usage:
+    python3 scripts/migrations/backfill_clean_pdf_artifacts.py            # dry-run
+    python3 scripts/migrations/backfill_clean_pdf_artifacts.py --apply    # write
+    python3 scripts/migrations/backfill_clean_pdf_artifacts.py --collections interpretation decision
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Optional
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from scripts.core.database.source_versioning import (
+    build_source_version_id,
+    sha256_content,
+)
+from scripts.utils.pdf_text_cleaner import clean_pdf_artifacts, is_stub_content
+
+# Collections known to carry PDF-sourced artifacts (see analysis).
+DEFAULT_COLLECTIONS = [
+    "interpretation",
+    "decision",
+    "judgment",
+    "case",
+    "constitutional_decc",
+    "admin_decc",
+    "mediation_case",
+    "adrule",
+]
+
+
+def plan_document_update(document: dict, collection: str) -> Optional[tuple[str, dict]]:
+    """Plan a single document's cleanup.
+
+    Returns ``(kind, set_fields)`` where ``kind`` is ``"clean"`` or ``"stub"``,
+    or ``None`` when the document needs no change.
+    """
+    content = document.get("content") or ""
+
+    if is_stub_content(content):
+        metadata = document.get("metadata") or {}
+        if metadata.get("is_stub") and metadata.get("is_searchable") is False:
+            return None
+        return "stub", {
+            "metadata.is_stub": True,
+            "metadata.is_searchable": False,
+        }
+
+    cleaned = clean_pdf_artifacts(content)
+    if cleaned == content:
+        return None
+
+    content_hash = sha256_content(cleaned)
+    chunk_id = str(document.get("chunk_id") or document.get("doc_id") or "").strip()
+    return "clean", {
+        "content": cleaned,
+        "content_hash": content_hash,
+        "source_version_id": build_source_version_id(collection, chunk_id, content_hash),
+    }
+
+
+def plan_collection_cleanup(documents, collection: str) -> list[tuple[object, str, dict]]:
+    """Plan cleanup for an iterable of documents.
+
+    Returns a list of ``(_id, kind, set_fields)`` for documents needing a
+    change; documents that need none are omitted.
+    """
+    plans = []
+    for document in documents:
+        planned = plan_document_update(document, collection)
+        if planned is None:
+            continue
+        kind, set_fields = planned
+        plans.append((document.get("_id"), kind, set_fields))
+    return plans
+
+
+def run_cleanup(db, collections, apply: bool) -> dict:
+    """Scan and (optionally) apply cleanup across ``collections``.
+
+    Returns a per-collection summary dict.
+    """
+    summary = {}
+    for name in collections:
+        collection = db[name]
+        cursor = collection.find(
+            {},
+            {"content": 1, "chunk_id": 1, "doc_id": 1, "metadata": 1},
+        )
+        plans = plan_collection_cleanup(cursor, name)
+
+        cleaned = sum(1 for _, kind, _ in plans if kind == "clean")
+        stubbed = sum(1 for _, kind, _ in plans if kind == "stub")
+
+        if apply:
+            for _id, _kind, set_fields in plans:
+                collection.update_one({"_id": _id}, {"$set": set_fields})
+
+        summary[name] = {"cleaned": cleaned, "stubbed": stubbed, "total": len(plans)}
+        action = "applied" if apply else "dry-run"
+        print(f"[{action}] {name:22s} clean={cleaned:5d}  stub={stubbed:4d}")
+    return summary
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Strip PDF/print artifacts from MongoDB content")
+    parser.add_argument("--apply", action="store_true", help="write changes (default: dry-run)")
+    parser.add_argument(
+        "--collections",
+        nargs="+",
+        default=DEFAULT_COLLECTIONS,
+        help="collections to scan",
+    )
+    args = parser.parse_args()
+
+    from scripts.core.database.mongo_client import get_mongo_db
+
+    db = get_mongo_db()
+    summary = run_cleanup(db, args.collections, apply=args.apply)
+
+    total_clean = sum(s["cleaned"] for s in summary.values())
+    total_stub = sum(s["stubbed"] for s in summary.values())
+    mode = "APPLIED" if args.apply else "DRY-RUN (use --apply to write)"
+    print(f"\n{mode}: {total_clean} cleaned, {total_stub} stub-flagged")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/pdf_ingest/pdf_to_mongo.py
+++ b/scripts/pdf_ingest/pdf_to_mongo.py
@@ -23,6 +23,7 @@ import pymupdf  # pip install pymupdf
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 from scripts.core.database.mongo_client import MongoClientSingleton
+from scripts.utils.pdf_text_cleaner import clean_pdf_artifacts
 
 # PDF 파일 디렉토리 (Mac Mini 경로)
 PDF_BASE = Path("/Users/loum/loum/pdf_db")
@@ -50,7 +51,9 @@ def extract_pdf_text(pdf_path: Path) -> str:
             if text.strip():
                 pages.append(text.strip())
         doc.close()
-        return "\n\n".join(pages)
+        # Strip print footers (e.g. hrdb.kr print header/URL/page number) that
+        # repeat on every page, so they never enter the DB.
+        return clean_pdf_artifacts("\n\n".join(pages))
     except Exception as e:
         print(f"  ⚠ 텍스트 추출 실패 {pdf_path.name}: {e}")
         return ""

--- a/scripts/utils/pdf_text_cleaner.py
+++ b/scripts/utils/pdf_text_cleaner.py
@@ -1,0 +1,103 @@
+"""Strip PDF/print artifacts from crawled legal-document content.
+
+These artifacts are introduced when a document body is extracted from a PDF
+(directly via pymupdf in ``pdf_ingest``, or via the ``/api/extract-text``
+service for NLRC attachments). They are meaningless to a reader and leak the
+third-party source the PDF was printed from, so they must not appear in the
+B2B citation panel or the public search DB.
+
+Handled artifacts:
+  A. hrdb.kr browser print header/footer block — a print timestamp line,
+     one or two ``hrdb.kr/search/print?...`` URL lines, and a ``N/M`` page
+     indicator, repeated on every printed page.
+  B. NLRC page-break markers — a bare ``- N -`` line splitting a sentence.
+  C. Attachment filename markers — ``[첨부: <filename>]`` lines inserted when
+     concatenating multiple attachments.
+
+Stub documents (only ``제목:``/``출처: <url>`` and no real body) are detected
+separately via :func:`is_stub_content` so callers can flag rather than blank
+them.
+
+The cleaner is intentionally conservative: it only removes lines that match a
+structural artifact pattern exactly, so legitimate body text — in-line dates
+(``2017. 6. 22.``), ``오후경`` without a clock time, parenthetical citations
+like ``(출처 : 화학용어사전)`` — is left untouched.
+"""
+
+from __future__ import annotations
+
+import re
+
+# A print timestamp emitted by the browser print dialog, e.g. "26. 7. 3. 오후 3:14".
+# Requires a clock time (HH:MM) so in-body "2017. 6. 22. 오후경" is not matched.
+_PRINT_TIMESTAMP = re.compile(
+    r"^\s*\d{1,2}\.\s*\d{1,2}\.\s*\d{1,2}\.\s*오[전후]\s*\d{1,2}\s*:\s*\d{2}\s*$"
+)
+
+# An hrdb.kr print URL line (with or without scheme / www).
+_HRDB_URL = re.compile(r"^\s*(?:https?://)?(?:www\.)?hrdb\.kr/\S*\s*$", re.IGNORECASE)
+
+# A bare "N/M" page indicator line (only removed when part of a print footer).
+_PAGE_FRACTION = re.compile(r"^\s*\d{1,3}\s*/\s*\d{1,3}\s*$")
+
+# An NLRC page-break marker, e.g. "- 12 -" alone on a line.
+_PAGE_DASH = re.compile(r"^\s*-\s*\d{1,3}\s*-\s*$")
+
+# An attachment filename marker, e.g. "[첨부: 사례2.pdf]". The filename itself may
+# contain brackets (NLRC embeds case numbers, e.g. "재심판정서[중앙2018부해1095].pdf"),
+# so match greedily to the final "]" on the line. Requires the "첨부:" colon, so the
+# "[첨부파일 전문]" section label (no colon) is left intact.
+_ATTACHMENT = re.compile(r"^\s*\[첨부\s*[:：].*\]\s*$")
+
+# Stub-document prefixes.
+_TITLE_LINE = re.compile(r"^\s*제목\s*[:：]")
+_SOURCE_URL_LINE = re.compile(r"^\s*출처\s*[:：]\s*https?://")
+
+_EXCESS_BLANK_LINES = re.compile(r"\n{3,}")
+
+
+def clean_pdf_artifacts(text: str | None) -> str:
+    """Remove PDF print/page artifacts from ``text``.
+
+    Returns the cleaned text with excess blank lines collapsed and trimmed.
+    Returns an empty string for ``None``/empty input.
+    """
+    if not text:
+        return ""
+
+    kept: list[str] = []
+    prev_was_footer = False  # previous source line belonged to an hrdb print footer
+
+    for line in text.split("\n"):
+        if _PRINT_TIMESTAMP.match(line) or _HRDB_URL.match(line):
+            prev_was_footer = True
+            continue
+        # A page fraction is only an artifact when it trails a print footer.
+        if _PAGE_FRACTION.match(line) and prev_was_footer:
+            continue
+        if _PAGE_DASH.match(line) or _ATTACHMENT.match(line):
+            prev_was_footer = False
+            continue
+        prev_was_footer = False
+        kept.append(line)
+
+    cleaned = "\n".join(kept)
+    cleaned = _EXCESS_BLANK_LINES.sub("\n\n", cleaned)
+    return cleaned.strip()
+
+
+def is_stub_content(text: str | None) -> bool:
+    """Return True when ``text`` has no real body beyond a title/source stub.
+
+    Documents whose entire content is ``제목: ...`` and ``출처: <url>`` (the
+    scraper's fallback when the real body could not be fetched) are stubs.
+    """
+    if not text or not text.strip():
+        return True
+
+    remainder = "\n".join(
+        line
+        for line in text.split("\n")
+        if not _TITLE_LINE.match(line) and not _SOURCE_URL_LINE.match(line)
+    ).strip()
+    return remainder == ""

--- a/tests/test_backfill_clean_pdf_artifacts.py
+++ b/tests/test_backfill_clean_pdf_artifacts.py
@@ -1,0 +1,97 @@
+import unittest
+
+from scripts.core.database.source_versioning import (
+    build_source_version_id,
+    sha256_content,
+)
+from scripts.migrations.backfill_clean_pdf_artifacts import (
+    plan_collection_cleanup,
+    plan_document_update,
+)
+
+
+HRDB_DOC = {
+    "_id": "x1",
+    "chunk_id": "interpretation:doc1",
+    "content": (
+        "육아휴직기간을 호봉승급기간에서 제외해도 타당한지\n"
+        "26. 7. 3. 오후 3:14\n"
+        "https://hrdb.kr/search/print?wm_id=1&pdf=1\n"
+        "1/1"
+    ),
+    "content_hash": "stale-hash",
+    "metadata": {"source_type": "pdf", "is_searchable": True},
+}
+
+
+class PlanDocumentUpdateTest(unittest.TestCase):
+    def test_hrdb_doc_plans_clean_update_with_recomputed_hash(self):
+        kind, set_fields = plan_document_update(HRDB_DOC, "interpretation")
+
+        expected_content = "육아휴직기간을 호봉승급기간에서 제외해도 타당한지"
+        expected_hash = sha256_content(expected_content)
+        self.assertEqual(kind, "clean")
+        self.assertEqual(set_fields["content"], expected_content)
+        self.assertEqual(set_fields["content_hash"], expected_hash)
+        self.assertEqual(
+            set_fields["source_version_id"],
+            build_source_version_id("interpretation", "interpretation:doc1", expected_hash),
+        )
+
+    def test_already_clean_doc_plans_nothing(self):
+        doc = {
+            "_id": "x2",
+            "chunk_id": "law:1",
+            "content": "남녀고용평등법 제11조는 강행규정으로서",
+            "content_hash": sha256_content("남녀고용평등법 제11조는 강행규정으로서"),
+            "metadata": {},
+        }
+
+        self.assertIsNone(plan_document_update(doc, "law"))
+
+    def test_stub_doc_plans_flag_without_touching_content(self):
+        doc = {
+            "_id": "x3",
+            "chunk_id": "constitutional_decc:1",
+            "content": "제목: 고용보험법 제23조 위헌소원\n출처: https://www.law.go.kr/x",
+            "metadata": {"is_searchable": True},
+        }
+
+        kind, set_fields = plan_document_update(doc, "constitutional_decc")
+
+        self.assertEqual(kind, "stub")
+        self.assertNotIn("content", set_fields)
+        self.assertEqual(set_fields["metadata.is_stub"], True)
+        self.assertEqual(set_fields["metadata.is_searchable"], False)
+
+    def test_already_flagged_stub_plans_nothing(self):
+        doc = {
+            "_id": "x4",
+            "chunk_id": "constitutional_decc:1",
+            "content": "제목: 어떤 것\n출처: https://x",
+            "metadata": {"is_stub": True, "is_searchable": False},
+        }
+
+        self.assertIsNone(plan_document_update(doc, "constitutional_decc"))
+
+
+class PlanCollectionCleanupTest(unittest.TestCase):
+    def test_collects_only_changed_documents(self):
+        clean_doc = {
+            "_id": "c1",
+            "chunk_id": "law:1",
+            "content": "정상 본문",
+            "metadata": {},
+        }
+        docs = [HRDB_DOC, clean_doc]
+
+        plans = plan_collection_cleanup(docs, "interpretation")
+
+        self.assertEqual(len(plans), 1)
+        _id, kind, set_fields = plans[0]
+        self.assertEqual(_id, "x1")
+        self.assertEqual(kind, "clean")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pdf_text_cleaner.py
+++ b/tests/test_pdf_text_cleaner.py
@@ -1,0 +1,196 @@
+import unittest
+
+from scripts.utils.pdf_text_cleaner import (
+    clean_pdf_artifacts,
+    is_stub_content,
+)
+
+
+class CleanHrdbFooterTest(unittest.TestCase):
+    def test_removes_hrdb_print_footer_block(self):
+        text = (
+            "육아휴직기간을 호봉승급기간에서 제외해도 타당한지\n"
+            "26. 7. 3. 오후 3:14\n"
+            "hrdb.kr/search/print?wm_id=29286&pdf=1\n"
+            "https://hrdb.kr/search/print?wm_id=29286&pdf=1\n"
+            "1/1"
+        )
+
+        cleaned = clean_pdf_artifacts(text)
+
+        self.assertEqual(cleaned, "육아휴직기간을 호봉승급기간에서 제외해도 타당한지")
+        self.assertNotIn("hrdb", cleaned)
+
+    def test_removes_hrdb_footer_with_www_variant(self):
+        text = (
+            "직위해제 및 대기명령 처분사유가 일부만 해당되는 경우\n"
+            "26. 7. 1. 오후 10:41\n"
+            "hrdb.kr/search/print?wm_id=23934&pdf=1\n"
+            "https://www.hrdb.kr/search/print?wm_id=23934&pdf=1\n"
+            "5/11\n"
+            "\n"
+            "- 두 번째 사유인 같은 규정 제47조"
+        )
+
+        cleaned = clean_pdf_artifacts(text)
+
+        self.assertNotIn("hrdb", cleaned)
+        self.assertNotIn("5/11", cleaned)
+        self.assertIn("직위해제 및 대기명령", cleaned)
+        self.assertIn("- 두 번째 사유인 같은 규정 제47조", cleaned)
+
+    def test_removes_footer_embedded_mid_content(self):
+        text = (
+            "앞 문장.\n"
+            "26. 7. 3. 오후 3:14\n"
+            "https://hrdb.kr/search/print?wm_id=1&pdf=1\n"
+            "2/3\n"
+            "\n"
+            "뒤 문장."
+        )
+
+        cleaned = clean_pdf_artifacts(text)
+
+        self.assertIn("앞 문장.", cleaned)
+        self.assertIn("뒤 문장.", cleaned)
+        self.assertNotIn("hrdb", cleaned)
+        self.assertNotIn("오후 3:14", cleaned)
+
+
+class KeepLegitimateContentTest(unittest.TestCase):
+    def test_keeps_inbody_dates_without_time(self):
+        text = (
+            "○○○○하우스는 2017. 9. 21. 원고와 공사기간을 정하였다. "
+            "원고는 2017. 10. 30. 계약을 체결하였다."
+        )
+
+        self.assertEqual(clean_pdf_artifacts(text), text)
+
+    def test_keeps_inbody_ohu_without_clock_time(self):
+        # "오후경" (no HH:MM) is legitimate body text, not a print timestamp
+        text = "근로자들과 2017. 11. 6. 오후경부터 잭서포트를 해체하는 작업을 수행하였다."
+
+        self.assertEqual(clean_pdf_artifacts(text), text)
+
+    def test_keeps_inline_source_citation(self):
+        # parenthetical "(출처 : 화학용어사전)" is real legal text
+        text = "유리소지에 대한 용어정리(출처 : 화학용어사전) - '소지'란 원료혼합물을 말한다."
+
+        self.assertEqual(clean_pdf_artifacts(text), text)
+
+    def test_clean_content_is_unchanged(self):
+        text = (
+            "업무수행 평가결과에 따른 인센티브, 기준물량 초과 시 분기마다"
+            "지급하는 격려금의 임금성"
+        )
+
+        self.assertEqual(clean_pdf_artifacts(text), text)
+
+
+class NlrcPageMarkerTest(unittest.TestCase):
+    def test_removes_page_break_marker_line(self):
+        text = (
+            "안전사고가 발생할 수 있는 점이 고려되어야 한다.\n"
+            "\n"
+            "- 12 -\n"
+            "\n"
+            "하루 출입횟수 8회 제한을 계열사에 적용한 것은 과하지 않다."
+        )
+
+        cleaned = clean_pdf_artifacts(text)
+
+        self.assertNotIn("- 12 -", cleaned)
+        self.assertIn("고려되어야 한다.", cleaned)
+        self.assertIn("하루 출입횟수 8회 제한을", cleaned)
+
+    def test_keeps_dash_enclosed_words(self):
+        # a real "- 단어 -" style emphasis must not be removed (only numeric markers)
+        text = "이 사건 - 근로자 - 는 정당한 사유가 있었다."
+
+        self.assertEqual(clean_pdf_artifacts(text), text)
+
+
+class AttachmentMarkerTest(unittest.TestCase):
+    def test_removes_attachment_filename_marker(self):
+        text = (
+            "판정요지: 부당노동행위에 해당하지 않는다.\n"
+            "\n"
+            "[첨부: 사례2.pdf]\n"
+            "사례 2\n"
+            "[2025. 12. 22. 판정 / 초심: 일부 인정]"
+        )
+
+        cleaned = clean_pdf_artifacts(text)
+
+        self.assertNotIn("[첨부: 사례2.pdf]", cleaned)
+        self.assertIn("판정요지: 부당노동행위에 해당하지 않는다.", cleaned)
+        self.assertIn("사례 2", cleaned)
+
+    def test_removes_attachment_marker_with_bracketed_filename(self):
+        # NLRC filenames embed case numbers in brackets, e.g.
+        # "재심판정서[중앙2018부해1095]-8.기타징계.pdf"
+        text = (
+            "부당하다고 판정한 사례\n"
+            "\n"
+            "[첨부파일 전문]\n"
+            "[첨부: 재심판정서[중앙2018부해1095]-8.기타징계.pdf]\n"
+            "판 정 서"
+        )
+
+        cleaned = clean_pdf_artifacts(text)
+
+        self.assertNotIn("[첨부:", cleaned)
+        self.assertNotIn(".pdf", cleaned)
+        self.assertIn("[첨부파일 전문]", cleaned)  # section label kept
+        self.assertIn("판 정 서", cleaned)
+
+
+class WhitespaceTest(unittest.TestCase):
+    def test_collapses_excess_blank_lines(self):
+        text = "가.\n\n\n\n나."
+
+        self.assertEqual(clean_pdf_artifacts(text), "가.\n\n나.")
+
+    def test_idempotent(self):
+        text = (
+            "앞.\n26. 7. 3. 오후 3:14\nhttps://hrdb.kr/x\n1/1\n\n- 3 -\n\n뒤."
+        )
+
+        once = clean_pdf_artifacts(text)
+        twice = clean_pdf_artifacts(once)
+
+        self.assertEqual(once, twice)
+
+    def test_empty_and_none_safe(self):
+        self.assertEqual(clean_pdf_artifacts(""), "")
+        self.assertEqual(clean_pdf_artifacts(None), "")
+
+
+class StubDetectionTest(unittest.TestCase):
+    def test_title_source_only_is_stub(self):
+        text = (
+            "제목: 고용보험법 제23조 위헌소원\n"
+            "출처: https://www.law.go.kr/LSW/detcInfoP.do?mode=1&detcSeq=54676"
+        )
+
+        self.assertTrue(is_stub_content(text))
+
+    def test_real_body_is_not_stub(self):
+        text = (
+            "제목: 어떤 사건\n"
+            "출처: https://www.law.go.kr/x\n"
+            "[요지] 실제 본문 내용이 여기 있습니다."
+        )
+
+        self.assertFalse(is_stub_content(text))
+
+    def test_normal_content_is_not_stub(self):
+        self.assertFalse(is_stub_content("남녀고용평등법 제11조는 강행규정으로서"))
+
+    def test_empty_is_stub(self):
+        self.assertTrue(is_stub_content(""))
+        self.assertTrue(is_stub_content(None))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
8/17 로컬 커밋(e2b860f3)으로, 맥미니 작업본에는 이미 수동 반영되어 돌고 있던 내용의 정식 커밋본입니다 (핵심 3파일 해시 일치 확인). 테스트(pdf_text_cleaner 196줄 + backfill 97줄)와 백필 스크립트가 추가로 포함되어 있어 이쪽이 상위집합입니다.

맥미니 작업본 정리(미커밋 WIP 해소) 및 main 최신화의 일부로 올립니다 — judgment 사건번호 복구(#11)와 함께 merge 후 맥미니를 main으로 동기화합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)