### PR TITLE
feat(crawler): law.go.kr 일시장애 대비 전체 재시도 + 알림 문구 개선 (daily/weekly 통일)

### DIFF
--- a/crawl.py
+++ b/crawl.py
@@ -35,6 +35,33 @@ from scripts.core.config import get_scraper_config, get_scraper_list, ENV
 
 
 # ============================================================================
+# 종료 코드 (run_daily.sh 의 재시도 판단에 사용)
+# ============================================================================
+
+EXIT_OK = 0                 # 정상 (개별 문서 단위 실패만 있어도 여기 포함)
+EXIT_FATAL = 1              # 실행 자체가 중단됨 (예외/사용자 중단)
+EXIT_LISTING_FAILURE = 2    # URL 목록조차 수집 못한 스크래퍼 존재 → 외부 수집원 일시 장애 가능성, 재시도 대상
+
+
+def compute_exit_code(results: Dict[str, dict]) -> int:
+    """스크래퍼 결과 딕셔너리로 종료 코드를 결정한다.
+
+    URL 목록 수집 단계에서 실패(발견 URL 0개)한 스크래퍼가 하나라도 있으면
+    law.go.kr 등 외부 수집원의 일시 장애(점검·404)일 가능성이 높으므로
+    EXIT_LISTING_FAILURE(2)를 반환해 상위 스크립트가 전체 재시도를 하도록 한다.
+
+    개별 문서 단위 실패(목록은 정상 수집)만 있는 경우는 이미 문서 단위로 재시도되고
+    다음 실행에서 자연히 따라잡히므로 전체 재시도 대상으로 보지 않는다(EXIT_OK).
+    """
+    for result in results.values():
+        if not isinstance(result, dict):
+            continue
+        if result.get("status") == "failed" and not result.get("total_urls"):
+            return EXIT_LISTING_FAILURE
+    return EXIT_OK
+
+
+# ============================================================================
 # URL 아이템에서 리스트 페이지 URL 반환 (스크래퍼별 분기)
 # ============================================================================
 
@@ -598,17 +625,20 @@ def main():
         print(f"⏱️  소요 시간: {elapsed:.1f}분 ({int(elapsed // 60)}시간 {int(elapsed % 60)}분)")
         print()
 
-        return 0
+        exit_code = compute_exit_code(results)
+        if exit_code == EXIT_LISTING_FAILURE:
+            print("⚠️  일부 스크래퍼가 URL 목록 수집에 실패했습니다 (외부 수집원 일시 장애 가능성).")
+        return exit_code
 
     except KeyboardInterrupt:
         print("\n\n⚠️  사용자가 중단했습니다.")
-        return 1
+        return EXIT_FATAL
 
     except Exception as e:
         print(f"\n❌ 오류 발생: {e}")
         import traceback
         traceback.print_exc()
-        return 1
+        return EXIT_FATAL
 
 
 if __name__ == '__main__':

--- a/run_daily.sh
+++ b/run_daily.sh
@@ -30,12 +30,32 @@ cd "$CRAWLER_DIR"
 
 START_TIME=$(date +%s)
 
+# ── 외부 수집원(law.go.kr 등) 일시 장애 대비 전체 재시도 설정 ──
+# crawl.py 는 URL 목록조차 못 모은 스크래퍼가 있으면 종료코드 2를 반환한다.
+# 크롤링은 멱등(이미 크롤링된 URL 은 건너뜀)이라 전체 재시도 비용이 낮다.
+MAX_ATTEMPTS=3            # 총 시도 횟수 (최초 1 + 재시도 2)
+RETRY_WAIT_SECONDS=900   # 재시도 전 대기 (15분) — law.go.kr 새벽 점검 창을 넘기기 위함
+
 echo "======================================" >> "$LOG_FILE"
 echo "일일 업데이트 시작: $(date)" >> "$LOG_FILE"
 echo "======================================" >> "$LOG_FILE"
 
-"$PYTHON" -u crawl.py --mode update --since 1 --concurrent 3 >> "$LOG_FILE" 2>&1
-EXIT_CODE=$?
+ATTEMPT=1
+while true; do
+    echo "" >> "$LOG_FILE"
+    echo "▶ 크롤링 시도 ${ATTEMPT}/${MAX_ATTEMPTS}: $(date)" >> "$LOG_FILE"
+    "$PYTHON" -u crawl.py --mode update --since 1 --concurrent 3 >> "$LOG_FILE" 2>&1
+    EXIT_CODE=$?
+
+    # 종료코드 2(=URL 목록 수집 실패)일 때만 재시도. 그 외(정상/치명)면 종료.
+    if [ "$EXIT_CODE" -ne 2 ] || [ "$ATTEMPT" -ge "$MAX_ATTEMPTS" ]; then
+        break
+    fi
+
+    echo "⚠️ 외부 수집원 오류로 URL 목록 수집 실패 — ${RETRY_WAIT_SECONDS}초 후 재시도" >> "$LOG_FILE"
+    ATTEMPT=$((ATTEMPT + 1))
+    sleep "$RETRY_WAIT_SECONDS"
+done
 
 echo "======================================" >> "$LOG_FILE"
 echo "law/adrule 현재 시행 버전 재계산 시작: $(date)" >> "$LOG_FILE"
@@ -47,91 +67,10 @@ DURATION=$(( (END_TIME - START_TIME) / 60 ))
 
 echo "종료: $(date)" >> "$LOG_FILE"
 
-"$PYTHON" - << PYEOF
-import re, json, urllib.request
-
-log_file = "$LOG_FILE"
-webhook_url = "$DISCORD_WEBHOOK"
-duration = $DURATION
-exit_code = $EXIT_CODE
-date_str = "$DATE_STR"
-
-with open(log_file, 'r', encoding='utf-8') as f:
-    content = f.read()
-
-scrapers = ['law', 'adrule', 'case', 'decision', 'interpretation', 'mediation_case', 'judgment', 'constitutional_decc', 'legislation_expc', 'admin_decc']
-names = {
-    'law': '법령', 'adrule': '행정규칙', 'case': '판례',
-    'decision': '심의결정례', 'interpretation': '해석례',
-    'mediation_case': '조정사건례', 'judgment': '주요판정사례',
-    'constitutional_decc': '헌재결정례', 'legislation_expc': '법제처해석례', 'admin_decc': '행정심판재결례'
-}
-
-lines = content.split('\n')
-results = {}
-current = None
-
-for line in lines:
-    if '======' in line or '📈 전체 통계' in line:
-        current = None  # 전체 통계 섹션 진입 시 스크래퍼별 파싱 중단
-        continue
-    for scraper in scrapers:
-        if f'({scraper})' in line and ('✅' in line or '❌' in line):
-            current = scraper
-            results[scraper] = {'status': '✅' if '✅' in line else '❌', 'success': 0, 'skipped': 0, 'failed': 0, 'total': 0}
-            break
-    if current:
-        def pnum(pattern, text):
-            m = re.search(pattern + r'[^0-9]*([\d,]+)', text)
-            return int(m.group(1).replace(',', '')) if m else None
-        v = pnum(r'발견 URL', line)
-        if v is not None: results[current]['total'] = v
-        v = pnum(r'성공', line)
-        if v is not None: results[current]['success'] = v
-        v = pnum(r'실패', line)
-        if v is not None: results[current]['failed'] = v
-        v = pnum(r'건너뜀', line)
-        if v is not None: results[current]['skipped'] = v
-        v = pnum(r'변경없음', line)
-        if v is not None: results[current]['no_change'] = (results[current].get('no_change', 0) + v)
-
-total_updated = sum(r.get('success', 0) for r in results.values())
-total_no_change = sum(r.get('no_change', 0) for r in results.values())
-hours = duration // 60
-mins = duration % 60
-duration_str = f"{hours}시간 {mins}분" if hours > 0 else f"{mins}분"
-
-out = [f"📊 **일일 크롤러 업데이트** ({date_str})\n"]
-
-for scraper in scrapers:
-    r = results.get(scraper)
-    name = names[scraper]
-    if not r:
-        out.append(f"⬜ {name}: 미실행")
-    elif r['status'] == '❌':
-        out.append(f"❌ {name}: 오류 발생")
-    else:
-        updated = r['success']
-        skipped = r['skipped']
-        no_change = r.get('no_change', 0)
-        if updated > 0:
-            out.append(f"✅ {name}: **{updated:,}건 업데이트** (변경없음 {no_change:,}건 / 건너뜀 {skipped:,}건)")
-        elif no_change > 0:
-            out.append(f"✅ {name}: 변경 없음 (재확인 {no_change:,}건 / 건너뜀 {skipped:,}건)")
-        else:
-            out.append(f"✅ {name}: 변경 없음 (건너뜀 {skipped:,}건)")
-
-out.append(f"\n🔢 전체 업데이트: **{total_updated:,}건** (변경없음 {total_no_change:,}건)  ⏱️ 소요시간: {duration_str}")
-
-if exit_code != 0:
-    out.append("⚠️ 일부 오류 발생 — 로그 확인 필요")
-
-msg = '\n'.join(out)
-payload = json.dumps({"content": msg}).encode('utf-8')
-req = urllib.request.Request(webhook_url, data=payload, headers={'Content-Type': 'application/json', 'User-Agent': 'DiscordBot (private, 1.0)'}, method='POST')
-try:
-    urllib.request.urlopen(req)
-    print("Discord 알림 전송 완료")
-except Exception as e:
-    print(f"Discord 알림 전송 실패: {e}")
-PYEOF
+# 알림 메시지 생성·전송은 테스트 가능한 파이썬 모듈로 위임 (scripts/notify/daily_summary.py)
+"$PYTHON" -u scripts/notify/daily_summary.py \
+    --log "$LOG_FILE" \
+    --webhook "$DISCORD_WEBHOOK" \
+    --duration "$DURATION" \
+    --attempts "$ATTEMPT" \
+    --date "$DATE_STR" >> "$LOG_FILE" 2>&1

--- a/run_weekly.sh
+++ b/run_weekly.sh
@@ -11,91 +11,41 @@ cd "$CRAWLER_DIR"
 
 START_TIME=$(date +%s)
 
+# ── 외부 수집원(law.go.kr 등) 일시 장애 대비 전체 재시도 설정 (run_daily.sh 와 동일) ──
+MAX_ATTEMPTS=3            # 총 시도 횟수 (최초 1 + 재시도 2)
+RETRY_WAIT_SECONDS=900   # 재시도 전 대기 (15분)
+
 echo "======================================" >> "$LOG_FILE"
 echo "주간 업데이트 시작: $(date)" >> "$LOG_FILE"
 echo "======================================" >> "$LOG_FILE"
 
-"$PYTHON" -u crawl.py --mode update --since 7 --concurrent 3 >> "$LOG_FILE" 2>&1
-EXIT_CODE=$?
+ATTEMPT=1
+while true; do
+    echo "" >> "$LOG_FILE"
+    echo "▶ 크롤링 시도 ${ATTEMPT}/${MAX_ATTEMPTS}: $(date)" >> "$LOG_FILE"
+    "$PYTHON" -u crawl.py --mode update --since 7 --concurrent 3 >> "$LOG_FILE" 2>&1
+    EXIT_CODE=$?
+
+    # 종료코드 2(=URL 목록 수집 실패)일 때만 재시도. 그 외(정상/치명)면 종료.
+    if [ "$EXIT_CODE" -ne 2 ] || [ "$ATTEMPT" -ge "$MAX_ATTEMPTS" ]; then
+        break
+    fi
+
+    echo "⚠️ 외부 수집원 오류로 URL 목록 수집 실패 — ${RETRY_WAIT_SECONDS}초 후 재시도" >> "$LOG_FILE"
+    ATTEMPT=$((ATTEMPT + 1))
+    sleep "$RETRY_WAIT_SECONDS"
+done
 
 END_TIME=$(date +%s)
 DURATION=$(( (END_TIME - START_TIME) / 60 ))
 
 echo "종료: $(date)" >> "$LOG_FILE"
 
-# Discord 알림 전송
-"$PYTHON" - << PYEOF
-import re, json, urllib.request
-
-log_file = "$LOG_FILE"
-webhook_url = "$DISCORD_WEBHOOK"
-duration = $DURATION
-exit_code = $EXIT_CODE
-date_str = "$DATE_STR"
-
-with open(log_file, 'r', encoding='utf-8') as f:
-    content = f.read()
-
-scrapers = ['law', 'adrule', 'case', 'decision', 'interpretation', 'mediation_case', 'judgment']
-names = {
-    'law': '법령', 'adrule': '행정규칙', 'case': '판례',
-    'decision': '심의결정례', 'interpretation': '해석례',
-    'mediation_case': '조정사건례', 'judgment': '주요판정사례'
-}
-
-lines = content.split('\n')
-results = {}
-current = None
-
-for line in lines:
-    for scraper in scrapers:
-        if f'({scraper})' in line and ('✅' in line or '❌' in line):
-            current = scraper
-            results[scraper] = {'status': '✅' if '✅' in line else '❌', 'success': 0, 'skipped': 0, 'failed': 0, 'total': 0}
-            break
-    if current:
-        def pnum(pattern, text):
-            m = re.search(pattern + r'[^0-9]*([\d,]+)', text)
-            return int(m.group(1).replace(',', '')) if m else None
-        v = pnum(r'발견 URL', line)
-        if v is not None: results[current]['total'] = v
-        v = pnum(r'성공', line)
-        if v is not None: results[current]['success'] = v
-        v = pnum(r'실패', line)
-        if v is not None: results[current]['failed'] = v
-        v = pnum(r'건너뜀', line)
-        if v is not None: results[current]['skipped'] = v
-
-total_updated = sum(r.get('success', 0) for r in results.values())
-hours = duration // 60
-mins = duration % 60
-duration_str = f"{hours}시간 {mins}분" if hours > 0 else f"{mins}분"
-
-out = [f"📊 **주간 크롤러 업데이트** ({date_str})\n"]
-
-for scraper in scrapers:
-    r = results.get(scraper)
-    name = names[scraper]
-    if not r:
-        out.append(f"⬜ {name}: 미실행")
-    elif r['status'] == '❌':
-        out.append(f"❌ {name}: 오류 발생")
-    else:
-        updated = r['success']
-        skipped = r['skipped']
-        if updated > 0:
-            out.append(f"✅ {name}: **{updated}건 업데이트** (건너뜀 {skipped}건)")
-        else:
-            out.append(f"✅ {name}: 변경 없음 (건너뜀 {skipped}건)")
-
-out.append(f"\n🔢 전체 업데이트: **{total_updated}건**  ⏱️ 소요시간: {duration_str}")
-
-msg = '\n'.join(out)
-payload = json.dumps({"content": msg}).encode('utf-8')
-req = urllib.request.Request(webhook_url, data=payload, headers={'Content-Type': 'application/json', 'User-Agent': 'DiscordBot (private, 1.0)'}, method='POST')
-try:
-    urllib.request.urlopen(req)
-    print("Discord 알림 전송 완료")
-except Exception as e:
-    print(f"Discord 알림 전송 실패: {e}")
-PYEOF
+# 알림 메시지 생성·전송은 테스트 가능한 파이썬 모듈로 위임 (run_daily.sh 와 동일 모듈)
+"$PYTHON" -u scripts/notify/daily_summary.py \
+    --log "$LOG_FILE" \
+    --webhook "$DISCORD_WEBHOOK" \
+    --duration "$DURATION" \
+    --attempts "$ATTEMPT" \
+    --date "$DATE_STR" \
+    --title "주간 크롤러 업데이트" >> "$LOG_FILE" 2>&1

--- a/scripts/notify/daily_summary.py
+++ b/scripts/notify/daily_summary.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""일일 크롤러 실행 로그를 파싱해 Discord 알림 메시지를 만들고 전송한다.
+
+run_daily.sh 의 인라인 heredoc 를 대체한다. 메시지 생성 로직(build_message)은
+순수 함수라 tests/test_daily_summary_message.py 로 검증한다.
+"""
+import argparse
+import json
+import re
+import urllib.request
+
+
+SCRAPERS = [
+    'law', 'adrule', 'case', 'decision', 'interpretation',
+    'mediation_case', 'judgment', 'constitutional_decc', 'legislation_expc', 'admin_decc',
+]
+
+NAMES = {
+    'law': '법령', 'adrule': '행정규칙', 'case': '판례',
+    'decision': '심의결정례', 'interpretation': '해석례',
+    'mediation_case': '조정사건례', 'judgment': '주요판정사례',
+    'constitutional_decc': '헌재결정례', 'legislation_expc': '법제처해석례', 'admin_decc': '행정심판재결례',
+}
+
+
+def _pnum(pattern, text):
+    m = re.search(pattern + r'[^0-9]*([\d,]+)', text)
+    return int(m.group(1).replace(',', '')) if m else None
+
+
+def parse_scraper_results(log_content: str) -> dict:
+    """크롤링 최종 결과 섹션을 파싱한다.
+
+    로그에 여러 번의 시도가 append 된 경우(재시도), 각 스크래퍼의 마지막 결과 블록이
+    최종 상태를 나타내므로 뒤에 나오는 값이 앞의 값을 덮어쓴다.
+    """
+    results = {}
+    current = None
+    for line in log_content.split('\n'):
+        if '======' in line or '📈 전체 통계' in line:
+            current = None  # 전체 통계 섹션 진입 시 스크래퍼별 파싱 중단
+            continue
+        for scraper in SCRAPERS:
+            if f'({scraper})' in line and ('✅' in line or '❌' in line):
+                current = scraper
+                results[scraper] = {
+                    'status': '✅' if '✅' in line else '❌',
+                    'success': 0, 'skipped': 0, 'failed': 0, 'total': 0, 'no_change': 0,
+                }
+                break
+        if current:
+            v = _pnum(r'발견 URL', line)
+            if v is not None:
+                results[current]['total'] = v
+            v = _pnum(r'성공', line)
+            if v is not None:
+                results[current]['success'] = v
+            v = _pnum(r'실패', line)
+            if v is not None:
+                results[current]['failed'] = v
+            v = _pnum(r'건너뜀', line)
+            if v is not None:
+                results[current]['skipped'] = v
+            v = _pnum(r'변경없음', line)
+            if v is not None:
+                results[current]['no_change'] = v
+    return results
+
+
+def build_message(log_content: str, duration_min: int, attempts: int, date_str: str) -> str:
+    """로그 내용으로 Discord 알림 메시지 문자열을 만든다."""
+    results = parse_scraper_results(log_content)
+
+    total_updated = sum(r.get('success', 0) for r in results.values())
+    total_no_change = sum(r.get('no_change', 0) for r in results.values())
+
+    hours = duration_min // 60
+    mins = duration_min % 60
+    duration_str = f"{hours}시간 {mins}분" if hours > 0 else f"{mins}분"
+
+    out = [f"📊 **일일 크롤러 업데이트** ({date_str})\n"]
+
+    listing_failures = []  # URL 목록조차 못 모은 스크래퍼 (외부 수집원 장애 신호)
+    other_failures = []    # 목록은 모았으나 실패 상태인 스크래퍼
+
+    for scraper in SCRAPERS:
+        r = results.get(scraper)
+        name = NAMES[scraper]
+        if not r:
+            out.append(f"⬜ {name}: 미실행")
+        elif r['status'] == '❌':
+            if r.get('total', 0) == 0:
+                # law.go.kr 404 처럼 목록 수집 자체가 실패 → 외부 수집원 문제로 명시
+                listing_failures.append(name)
+                out.append(f"⚠️ {name}: 수집원 일시 오류 (URL 목록 수집 실패)")
+            else:
+                other_failures.append(name)
+                out.append(f"❌ {name}: 일부 문서 처리 실패 (실패 {r.get('failed', 0):,}건)")
+        else:
+            updated = r['success']
+            skipped = r['skipped']
+            no_change = r.get('no_change', 0)
+            if updated > 0:
+                out.append(f"✅ {name}: **{updated:,}건 업데이트** (변경없음 {no_change:,}건 / 건너뜀 {skipped:,}건)")
+            elif no_change > 0:
+                out.append(f"✅ {name}: 변경 없음 (재확인 {no_change:,}건 / 건너뜀 {skipped:,}건)")
+            else:
+                out.append(f"✅ {name}: 변경 없음 (건너뜀 {skipped:,}건)")
+
+    out.append(
+        f"\n🔢 전체 업데이트: **{total_updated:,}건** (변경없음 {total_no_change:,}건)  "
+        f"⏱️ 소요시간: {duration_str}"
+    )
+
+    retries = max(0, attempts - 1)
+    if retries > 0:
+        out.append(f"🔁 외부 수집원 오류로 {retries}회 재시도함")
+
+    if listing_failures:
+        out.append(
+            f"⚠️ law.go.kr 등 외부 수집원 일시 오류로 {', '.join(listing_failures)} 미수집 "
+            f"— 데이터 유실 아님(다음 실행 시 자동 반영)"
+        )
+    if other_failures:
+        out.append(f"❗ {', '.join(other_failures)} 일부 문서 실패 — 로그 확인 필요")
+
+    return '\n'.join(out)
+
+
+def send_discord(webhook_url: str, message: str) -> None:
+    payload = json.dumps({"content": message}).encode('utf-8')
+    req = urllib.request.Request(
+        webhook_url,
+        data=payload,
+        headers={'Content-Type': 'application/json', 'User-Agent': 'DiscordBot (private, 1.0)'},
+        method='POST',
+    )
+    urllib.request.urlopen(req)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="일일 크롤러 Discord 알림 전송")
+    parser.add_argument('--log', required=True, help='daily 로그 파일 경로')
+    parser.add_argument('--webhook', required=True, help='Discord webhook URL')
+    parser.add_argument('--duration', type=int, default=0, help='소요 시간(분)')
+    parser.add_argument('--attempts', type=int, default=1, help='크롤링 시도 횟수 (재시도 포함)')
+    parser.add_argument('--date', default='', help='표시용 날짜 문자열')
+    args = parser.parse_args()
+
+    with open(args.log, 'r', encoding='utf-8') as f:
+        content = f.read()
+
+    msg = build_message(content, args.duration, args.attempts, args.date)
+
+    try:
+        send_discord(args.webhook, msg)
+        print("Discord 알림 전송 완료")
+    except Exception as e:  # noqa: BLE001 - 알림 실패가 크롤링을 막지 않도록
+        print(f"Discord 알림 전송 실패: {e}")
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/notify/daily_summary.py
+++ b/scripts/notify/daily_summary.py
@@ -67,7 +67,13 @@ def parse_scraper_results(log_content: str) -> dict:
     return results
 
 
-def build_message(log_content: str, duration_min: int, attempts: int, date_str: str) -> str:
+def build_message(
+    log_content: str,
+    duration_min: int,
+    attempts: int,
+    date_str: str,
+    title: str = "일일 크롤러 업데이트",
+) -> str:
     """로그 내용으로 Discord 알림 메시지 문자열을 만든다."""
     results = parse_scraper_results(log_content)
 
@@ -78,7 +84,7 @@ def build_message(log_content: str, duration_min: int, attempts: int, date_str: 
     mins = duration_min % 60
     duration_str = f"{hours}시간 {mins}분" if hours > 0 else f"{mins}분"
 
-    out = [f"📊 **일일 크롤러 업데이트** ({date_str})\n"]
+    out = [f"📊 **{title}** ({date_str})\n"]
 
     listing_failures = []  # URL 목록조차 못 모은 스크래퍼 (외부 수집원 장애 신호)
     other_failures = []    # 목록은 모았으나 실패 상태인 스크래퍼
@@ -145,12 +151,13 @@ def main():
     parser.add_argument('--duration', type=int, default=0, help='소요 시간(분)')
     parser.add_argument('--attempts', type=int, default=1, help='크롤링 시도 횟수 (재시도 포함)')
     parser.add_argument('--date', default='', help='표시용 날짜 문자열')
+    parser.add_argument('--title', default='일일 크롤러 업데이트', help='메시지 제목')
     args = parser.parse_args()
 
     with open(args.log, 'r', encoding='utf-8') as f:
         content = f.read()
 
-    msg = build_message(content, args.duration, args.attempts, args.date)
+    msg = build_message(content, args.duration, args.attempts, args.date, title=args.title)
 
     try:
         send_discord(args.webhook, msg)

--- a/tests/test_crawl_exit_code.py
+++ b/tests/test_crawl_exit_code.py
@@ -1,0 +1,39 @@
+import unittest
+
+from crawl import EXIT_OK, EXIT_LISTING_FAILURE, compute_exit_code
+
+
+class ComputeExitCodeTest(unittest.TestCase):
+    def test_all_success_returns_ok(self):
+        results = {
+            "law": {"status": "success", "total_urls": 165},
+            "case": {"status": "success", "total_urls": 30000},
+        }
+        self.assertEqual(compute_exit_code(results), EXIT_OK)
+
+    def test_listing_failure_zero_urls_is_retryable(self):
+        # law.go.kr 404 처럼 URL 목록조차 못 모은 경우 → 재시도 대상
+        results = {
+            "law": {"status": "failed", "error": "404", "total_urls": 0},
+            "mediation_case": {"status": "success", "total_urls": 78, "skipped": 78},
+        }
+        self.assertEqual(compute_exit_code(results), EXIT_LISTING_FAILURE)
+
+    def test_failed_status_without_total_urls_key_is_retryable(self):
+        results = {"law": {"status": "failed", "error": "boom"}}
+        self.assertEqual(compute_exit_code(results), EXIT_LISTING_FAILURE)
+
+    def test_doc_level_failures_with_urls_found_are_not_retryable(self):
+        # 목록은 정상 수집됐고 개별 문서만 일부 실패 → 전체 재시도 대상 아님
+        results = {
+            "law": {"status": "failed", "total_urls": 165, "total_success": 100, "total_failed": 65},
+        }
+        self.assertEqual(compute_exit_code(results), EXIT_OK)
+
+    def test_non_dict_values_are_ignored(self):
+        results = {"law": {"status": "success", "total_urls": 1}, "case": ValueError("x")}
+        self.assertEqual(compute_exit_code(results), EXIT_OK)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_daily_summary_message.py
+++ b/tests/test_daily_summary_message.py
@@ -1,0 +1,82 @@
+import unittest
+
+from scripts.notify.daily_summary import build_message, parse_scraper_results
+
+
+SUCCESS_LOG = """
+✅ 법령 (law)
+   - 발견 URL: 165개
+   - 성공: 0개
+   - 변경없음: 0개
+   - 실패: 0개
+   - 건너뜀: 165개 (이미 크롤링됨)
+
+✅ 판례 (case)
+   - 발견 URL: 30,000개
+   - 성공: 3개
+   - 변경없음: 0개
+   - 실패: 0개
+   - 건너뜀: 29,997개 (이미 크롤링됨)
+
+================================================================================
+📈 전체 통계
+================================================================================
+"""
+
+# law.go.kr 404 로 목록조차 못 모은 밤 (2026-08-22 재현)
+LISTING_FAILURE_LOG = """
+❌ 법령 (law)
+   - 발견 URL: 0개
+   - 성공: 0개
+   - 변경없음: 0개
+   - 실패: 0개
+
+✅ 심의결정례 (decision)
+   - 발견 URL: 511개
+   - 성공: 0개
+   - 변경없음: 0개
+   - 실패: 0개
+   - 건너뜀: 511개 (이미 크롤링됨)
+
+================================================================================
+📈 전체 통계
+================================================================================
+"""
+
+
+class ParseScraperResultsTest(unittest.TestCase):
+    def test_listing_failure_detected_by_zero_urls(self):
+        results = parse_scraper_results(LISTING_FAILURE_LOG)
+        self.assertEqual(results["law"]["status"], "❌")
+        self.assertEqual(results["law"]["total"], 0)
+        self.assertEqual(results["decision"]["status"], "✅")
+        self.assertEqual(results["decision"]["skipped"], 511)
+
+
+class BuildMessageTest(unittest.TestCase):
+    def test_success_message_has_no_alarm_footer(self):
+        msg = build_message(SUCCESS_LOG, duration_min=19, attempts=1, date_str="2026-08-23 00:00")
+        self.assertIn("일일 크롤러 업데이트", msg)
+        self.assertIn("✅ 판례", msg)
+        self.assertNotIn("외부 수집원", msg)
+        self.assertNotIn("재시도", msg)
+
+    def test_listing_failure_uses_external_source_wording_not_generic_error(self):
+        msg = build_message(LISTING_FAILURE_LOG, duration_min=32, attempts=3, date_str="2026-08-22 00:00")
+        # 원래 "오류 발생" 대신 외부 수집원 문구로 바뀌어야 한다
+        self.assertNotIn("오류 발생", msg)
+        self.assertIn("수집원", msg)
+        self.assertIn("법령", msg)
+
+    def test_listing_failure_reports_retry_count_and_no_data_loss(self):
+        msg = build_message(LISTING_FAILURE_LOG, duration_min=32, attempts=3, date_str="2026-08-22 00:00")
+        self.assertIn("2회 재시도", msg)          # attempts=3 → 재시도 2회
+        self.assertIn("데이터 유실", msg)          # 안심 문구
+
+    def test_single_attempt_success_omits_retry_line(self):
+        msg = build_message(SUCCESS_LOG, duration_min=19, attempts=1, date_str="2026-08-23 00:00")
+        self.assertNotIn("재시도", msg)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_daily_summary_message.py
+++ b/tests/test_daily_summary_message.py
@@ -77,6 +77,18 @@ class BuildMessageTest(unittest.TestCase):
         msg = build_message(SUCCESS_LOG, duration_min=19, attempts=1, date_str="2026-08-23 00:00")
         self.assertNotIn("재시도", msg)
 
+    def test_default_title_is_daily(self):
+        msg = build_message(SUCCESS_LOG, duration_min=19, attempts=1, date_str="2026-08-23 00:00")
+        self.assertIn("일일 크롤러 업데이트", msg)
+
+    def test_custom_title_used_for_weekly(self):
+        msg = build_message(
+            SUCCESS_LOG, duration_min=19, attempts=1, date_str="2026-08-23 00:00",
+            title="주간 크롤러 업데이트",
+        )
+        self.assertIn("주간 크롤러 업데이트", msg)
+        self.assertNotIn("일일 크롤러 업데이트", msg)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 배경
2026-08-22 일일 크롤러가 law.go.kr(국가법령정보센터) 404 로 법령·행정규칙·판례·해석례·헌재결정례·법제처해석례·행정심판재결례를 통째로 못 모았다. nlrc.go.kr 소스(심의결정례·조정사건례·주요판정사례)는 정상이었고, 다음 날 스스로 복구된 **외부 수집원 점검성 일시 장애**였다.

문제:
1. `crawl.py` 가 스크래퍼 다수가 404 로 실패해도 **종료코드 0** 을 반환 → 셸이 실패를 인지 못 해 재시도 불가.
2. 재시도 없이 그날치를 통째로 포기.
3. 알림이 `❌ 오류 발생` 으로만 표기돼 원인·영향 파악이 어려움.

## 변경
- **crawl.py**: `compute_exit_code()` — URL 목록조차 못 모은 스크래퍼가 있으면 종료코드 2(재시도 대상). 개별 문서 실패만 있으면 EXIT_OK.
- **run_daily.sh / run_weekly.sh**: 종료코드 2면 15분 뒤 전체 재시도(최대 3회). 크롤링이 멱등이라 재시도 비용 낮음. 두 스크립트가 재시도·알림 로직을 공유.
- **scripts/notify/daily_summary.py**: 인라인 heredoc 알림을 테스트 가능한 공용 모듈로 분리. 목록 수집 실패는 "수집원 일시 오류" 로 표기 + 재시도 횟수 + "데이터 유실 아님(다음 실행 시 자동 반영)" 안내. `--title` 로 일일/주간 구분.
- **tests**: `compute_exit_code`, `build_message` 단위 테스트 추가.

## 검증
- 전체 테스트 스위트 145 passed (신규 15개 포함).
- 실제 8/22 실패 로그 / 8/23 성공 로그로 메시지 렌더링 확인.